### PR TITLE
install gawk before running flatcar-install

### DIFF
--- a/hetzner/hetzner-machines.tf
+++ b/hetzner/hetzner-machines.tf
@@ -47,6 +47,8 @@ resource "hcloud_server" "machine" {
   provisioner "remote-exec" {
     inline = [
       "set -ex",
+      "apt update",
+      "apt install -y gawk",
       "curl -fsSLO --retry-delay 1 --retry 60 --retry-connrefused --retry-max-time 60 --connect-timeout 20 https://raw.githubusercontent.com/kinvolk/init/flatcar-master/bin/flatcar-install",
       "chmod +x flatcar-install",
       "./flatcar-install -s -i /root/ignition.json",


### PR DESCRIPTION
Without 'gawk', running 'terraform apply' fails with the following error

    hcloud_server.machine["mynode"]: Creating...
    hcloud_server.machine["mynode"]: Still creating... [10s elapsed]
    hcloud_server.machine["mynode"]: Still creating... [20s elapsed]
    hcloud_server.machine["mynode"]: Provisioning with 'file'...
    hcloud_server.machine["mynode"]: Still creating... [30s elapsed]
    hcloud_server.machine["mynode"]: Still creating... [40s elapsed]
    hcloud_server.machine["mynode"]: Provisioning with 'remote-exec'...
    hcloud_server.machine["mynode"] (remote-exec): Connecting to remote host via SSH...
    hcloud_server.machine["mynode"] (remote-exec):   Host: x.x.x.
    hcloud_server.machine["mynode"] (remote-exec):   User: root
    hcloud_server.machine["mynode"] (remote-exec):   Password: false
    hcloud_server.machine["mynode"] (remote-exec):   Private key: false
    hcloud_server.machine["mynode"] (remote-exec):   Certificate: false
    hcloud_server.machine["mynode"] (remote-exec):   SSH Agent: true
    hcloud_server.machine["mynode"] (remote-exec):   Checking Host Key: false
    hcloud_server.machine["mynode"] (remote-exec):   Target Platform: unix
    hcloud_server.machine["mynode"] (remote-exec): Connected!
    hcloud_server.machine["mynode"] (remote-exec): + curl -fsSLO --retry-delay 1 --retry 60 --retry-connrefused --retry-max-time 60 --connect-timeout 20 https://raw.githubusercontent.com/kinvolk/init/flatcar-master/bin/flatcar-install
    hcloud_server.machine["mynode"] (remote-exec): + chmod +x flatcar-install
    hcloud_server.machine["mynode"] (remote-exec): + ./flatcar-install -s -i /root/ignition.json
    hcloud_server.machine["mynode"] (remote-exec): error: command 'gawk' not found
    ╷
    │ Error: remote-exec provisioner error
    │
    │   with hcloud_server.machine["mynode"],
    │   on hetzner-machines.tf line 47, in resource "hcloud_server" "machine":
    │   47:   provisioner "remote-exec" {
    │
    │ error executing "/tmp/terraform_1044622600.sh": Process exited with status 1
    ╵

# Install gawk before running flatcar-install

Terraform apply fails with an error that gawk is not available. We need to install it first.

## How to use

Currently, you cannot use the provided terraform code to deploy a flatcar VM on Hetzner cloud.
To verify the commit, try to deploy a VM on Hetzner cloud with and without the change.

## Testing done

With this change, the output looks as follows and the provisioning of a flatcar VM is successful:

```
hcloud_server.machine["mynode"]: Provisioning with 'remote-exec'...
hcloud_server.machine["mynode"] (remote-exec): Connecting to remote host via SSH...
hcloud_server.machine["mynode"] (remote-exec):   Host: x.x.x.x
hcloud_server.machine["mynode"] (remote-exec):   User: root
hcloud_server.machine["mynode"] (remote-exec):   Password: false
hcloud_server.machine["mynode"] (remote-exec):   Private key: false
hcloud_server.machine["mynode"] (remote-exec):   Certificate: false
hcloud_server.machine["mynode"] (remote-exec):   SSH Agent: true
hcloud_server.machine["mynode"] (remote-exec):   Checking Host Key: false
hcloud_server.machine["mynode"] (remote-exec):   Target Platform: unix
hcloud_server.machine["mynode"] (remote-exec): Connected!
hcloud_server.machine["mynode"] (remote-exec): + apt update
hcloud_server.machine["mynode"] (remote-exec): 
hcloud_server.machine["mynode"] (remote-exec): 0% [Working]
hcloud_server.machine["mynode"] (remote-exec): Hit:1 http://mirror.hetzner.com/debian/packages bullseye InRelease
hcloud_server.machine["mynode"] (remote-exec): 
hcloud_server.machine["mynode"] (remote-exec): 0% [Connecting to debian.map.fastlydns.
hcloud_server.machine["mynode"] (remote-exec): Get:2 http://mirror.hetzner.com/debian/packages bullseye-updates InRelease [39.4 kB]
[..]
hcloud_server.machine["mynode"] (remote-exec): Get:21 http://deb.debian.org/debian bullseye-backports/non-free amd64 Packages [1,204 B]
[..]
hcloud_server.machine["mynode"] (remote-exec): Reading state information... Done
hcloud_server.machine["mynode"] (remote-exec): 2 packages can be upgraded. Run 'apt list --upgradable' to see them.
hcloud_server.machine["mynode"] (remote-exec): + apt install -y gawk
hcloud_server.machine["mynode"] (remote-exec): Reading package lists... 0%
[..]
hcloud_server.machine["mynode"] (remote-exec): Reading state information... Done
hcloud_server.machine["mynode"] (remote-exec): The following additional packages will be installed:
hcloud_server.machine["mynode"] (remote-exec):   libsigsegv2
hcloud_server.machine["mynode"] (remote-exec): Suggested packages:
hcloud_server.machine["mynode"] (remote-exec):   gawk-doc
hcloud_server.machine["mynode"] (remote-exec): The following NEW packages will be installed:
hcloud_server.machine["mynode"] (remote-exec):   gawk libsigsegv2
hcloud_server.machine["mynode"] (remote-exec): 0 upgraded, 2 newly installed, 0 to remove and 2 not upgraded.
hcloud_server.machine["mynode"] (remote-exec): Need to get 639 kB of archives.
hcloud_server.machine["mynode"] (remote-exec): After this operation, 2,578 kB of additional disk space will be used.
[..]
hcloud_server.machine["mynode"] (remote-exec): Processing triggers for libc-bin (2.31-13) ...
                                               + curl -fsSLO --retry-delay 1 --retry 60 --retry-connrefused --retry-max-time 60 --connect-timeout 20 https://raw.githubusercontent.com/kinvolk/init/flatcar-master/bin/flatcar-install
hcloud_server.machine["mynode"] (remote-exec): + chmod +x flatcar-install
hcloud_server.machine["mynode"] (remote-exec): + ./flatcar-install -s -i /root/ignition.json
hcloud_server.machine["mynode"] (remote-exec): Current version of Flatcar Container Linux stable is 2905.2.3
```
