### PR TITLE
equinix-metal-aka-packet-without-instance-replacement: keep machine ID

### DIFF
--- a/equinix-metal-aka-packet-without-instance-replacement/cl/machine-mynode.yaml.tmpl
+++ b/equinix-metal-aka-packet-without-instance-replacement/cl/machine-mynode.yaml.tmpl
@@ -14,6 +14,18 @@ storage:
           set -euo pipefail
           hostname="$(hostname)"
           echo My name is ${name} and the hostname is $${hostname}
+    - path: /reprovision
+      filesystem: oem
+      mode: 0755
+      contents:
+        inline: |
+          #!/bin/bash
+          set -euo pipefail
+          touch /usr/share/oem/grub.cfg
+          sed -i "/linux_append systemd.machine_id=.*/d" /usr/share/oem/grub.cfg
+          MI=$(cat /etc/machine-id)
+          echo "set linux_append=\"\$linux_append systemd.machine_id=$${MI}\"" >> /usr/share/oem/grub.cfg
+          touch /boot/flatcar/first_boot
   filesystems:
     - name: root
       mount:
@@ -21,3 +33,8 @@ storage:
         format: ext4
         wipe_filesystem: true
         label: ROOT
+    - name: oem
+      mount:
+        device: /dev/disk/by-label/OEM
+        format: btrfs
+        label: OEM

--- a/equinix-metal-aka-packet-without-instance-replacement/packet-machines.tf
+++ b/equinix-metal-aka-packet-without-instance-replacement/packet-machines.tf
@@ -33,7 +33,7 @@ resource "null_resource" "reboot-when-ignition-changes" {
   depends_on = [aws_s3_bucket_object.object]
   # Trigger running Ignition on the next reboot and reboot the instance (current limitation: also runs on the first provisioning)
   provisioner "local-exec" {
-    command = "while ! ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null core@${packet_device.machine[each.key].access_public_ipv4} sudo touch /boot/flatcar/first_boot ; do sleep 1; done; while ! ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null core@${packet_device.machine[each.key].access_public_ipv4} sudo systemctl reboot; do sleep 1; done"
+    command = "while ! ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null core@${packet_device.machine[each.key].access_public_ipv4} sudo /usr/share/oem/reprovision ; do sleep 1; done; while ! ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null core@${packet_device.machine[each.key].access_public_ipv4} sudo systemctl reboot; do sleep 1; done"
   }
 }
 


### PR DESCRIPTION
At least the machine ID can be preserved through the kernel parameters
when discarding the rootfs. In the future we might have methods to
retain file on the rootfs selectively but the machine ID would still
need to be passed through the kernel parameters because of systemd
first-boot semantics only working when the ID not present in
/etc/machine-id.


## How to use


## Testing done

